### PR TITLE
hashmap_get_pairs added; removed meta-arrays

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,18 @@ The core of the hashmap is implemented as an array of linked lists (for chaining
 
 There is a loading factor of 75% of the allocated size. The initial allocation size is 16 so the initial load factor is 12. Whenever the load factor is reached, the allocated size raises by the next power of two: 16 -> 32 -> 64 -> ... etc.
 
+# Time Complexity
+Time complexities will vary based off of how long the chains at each index are. Some indices could contain only a head node (constant time) or some could be several nodes deep (linear).
+* hashmap_get: O(1) (on average)
+* hashmap_put:
+    * without resizing: O(1)
+    * with resizing: O(n) (on average) -- when map dynamically resizes from load factor
+* hashmap_remove: O(1) (on average)
+* hashmap_get_pairs: O(n) (on average)
 # Example #1
 This example shows entering a bunch of keys and observing the hashmap dynamically grows as the load factor is reached.
 
-Then we search for a few existing keys, overwriting a value and searching a key that doesn't exist.
+Then we search for a few existing keys, overwrite a value within the map and searching a key that doesn't exist.
 
 ```c
 #include "hashmap.h"
@@ -197,4 +205,64 @@ After Removing:
 Key: bananas -- Value: 20
 Key: oranges -- Value: 40
 Key: watermelon -- Value: 50
+```
+# Example #3
+This example shows how to extract all the current key/values within a map and prints them to the console.
+```c
+#include "hashmap.h"
+
+int main()
+{
+    hashmap* map;
+    hashmap_init(&map);
+
+    int value = 10;
+    hashmap_put(map, "apples", &value, sizeof(int));
+
+    value = 20;
+    hashmap_put(map, "bananas", &value, sizeof(int));
+
+    value = 30;
+    hashmap_put(map, "grapes", &value, sizeof(int));
+
+    value = 40;
+    hashmap_put(map, "oranges", &value, sizeof(int));
+
+    value = 50;
+    hashmap_put(map, "cats", &value, sizeof(int));
+
+    hashmap_remove(&map, "grapes");
+    hashmap_remove(&map, "apples");
+    hashmap_remove(&map, "dogs"); // will be ignored since key doesn't exist
+
+    // client manages the memory to store local keys/values
+    char** keys = malloc(sizeof(char*) * map->total_size);
+    int* values = malloc(sizeof(int) * map->total_size);
+
+    hashmap_get_pairs(map, &keys, (void**)&values, sizeof(int));
+
+    // print out all key value pairs in map
+    // note the order will not necessarily be the same due to the hash function assigning
+    // different positions
+    for (size_t i = 0; i < map->total_size; ++i)
+        printf("Key: %s -- Value: %d\n", keys[i], values[i]);
+
+    // free up memory
+    for (size_t i = 0; i < map->total_size; ++i)
+        free(keys[i]);
+    free(keys);
+    free(values);
+
+    hashmap_free(&map);
+
+    return 0;
+}
+```
+Output:
+```text
+Key: oranges -- Value: 40
+Key: grapes -- Value: 30
+Key: apples -- Value: 10
+Key: cats -- Value: 50
+Key: bananas -- Value: 20
 ```

--- a/hashmap_testing.c
+++ b/hashmap_testing.c
@@ -18,19 +18,29 @@ int main()
     hashmap_put(map, "oranges", &value, sizeof(int));
 
     value = 50;
-    hashmap_put(map, "watermelon", &value, sizeof(int));
+    hashmap_put(map, "cats", &value, sizeof(int));
 
-    printf("Before Removing:\n");
-    for (size_t i = 0; i < map->n_used_keys; ++i)
-        printf("Key: %s -- Value: %d\n", map->used_keys[i], *(int*)map->used_values[i]);
-
-    hashmap_remove(&map, "apples");
     hashmap_remove(&map, "grapes");
-    hashmap_remove(&map, "thiskeydoesntexist"); // keys not in hashmap are ignored
+    hashmap_remove(&map, "apples");
+    hashmap_remove(&map, "dogs"); // will be ignored since key doesn't exist
 
-    printf("\nAfter Removing:\n");
-    for (size_t i = 0; i < map->n_used_keys; ++i)
-        printf("Key: %s -- Value: %d\n", map->used_keys[i], *(int*)map->used_values[i]);
+    // client manages the memory to store local keys/values
+    char** keys = malloc(sizeof(char*) * map->total_size);
+    int* values = malloc(sizeof(int) * map->total_size);
+
+    hashmap_get_pairs(map, &keys, (void**)&values, sizeof(int));
+
+    // print out all key value pairs in map
+    // note the order will not necessarily be the same due to the hash function assigning
+    // different positions
+    for (size_t i = 0; i < map->total_size; ++i)
+        printf("Key: %s -- Value: %d\n", keys[i], values[i]);
+
+    // free up memory
+    for (size_t i = 0; i < map->total_size; ++i)
+        free(keys[i]);
+    free(keys);
+    free(values);
 
     hashmap_free(&map);
 

--- a/include/hashmap.h
+++ b/include/hashmap.h
@@ -11,11 +11,7 @@ typedef struct
     size_t logical_size;
     size_t allocation_size;
     size_t load_factor_size;
-
-    char** used_keys;
-    void** used_values;
-    size_t n_used_keys;
-    size_t key_allocation_size;
+    size_t total_size;
 } hashmap;
 
 void hashmap_init(hashmap** map);
@@ -23,6 +19,8 @@ void hashmap_init(hashmap** map);
 void hashmap_put(hashmap* map, const char* key, void* value, size_t size);
 
 void* hashmap_get(hashmap* map, const char* key);
+
+void hashmap_get_pairs(hashmap* map, char*** keys, void** values, size_t size);
 
 void hashmap_remove(hashmap** map, const char* key);
 


### PR DESCRIPTION
removed used_keys and used_values arrays which was impacting time complexity for hashmap_remove in particular. now the dynamic resizing calls hashmap_get_pairs instead of storing two arrays separately. this also saves space in the hashmap struct.